### PR TITLE
feat: add scroll wheel mapping support

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -207,6 +207,7 @@ const charKeyMap: Record<string, Key> = {
   "`": Key.Grave,
 };
 keyboard.config.autoDelayMs = 0;
+mouse.config.autoDelayMs = 0;
 
 // Convert key name to nut-js Key enum
 function getNutKey(key: string): Key | null {
@@ -303,6 +304,30 @@ ipcMain.handle(
   }
 );
 
+// Handle mouse wheel scrolling requests
+ipcMain.handle("mouse-scroll", async (_event, deltaX: number, deltaY: number) => {
+  try {
+    const stepsX = Math.trunc(deltaX);
+    const stepsY = Math.trunc(deltaY);
+
+    if (stepsY < 0) {
+      await mouse.scrollUp(Math.abs(stepsY));
+    } else if (stepsY > 0) {
+      await mouse.scrollDown(stepsY);
+    }
+
+    if (stepsX < 0) {
+      await mouse.scrollLeft(Math.abs(stepsX));
+    } else if (stepsX > 0) {
+      await mouse.scrollRight(stepsX);
+    }
+
+    return { success: true };
+  } catch (error) {
+    console.error("Error scrolling mouse:", error);
+    return { success: false, error: String(error) };
+  }
+});
 
 // Handle key toggle requests
 ipcMain.handle("key-toggle", async (_event, key: string, down: boolean) => {

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -12,10 +12,14 @@ import {
 } from "electron";
 import os from "node:os";
 import path from "node:path";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { update } from "./update";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+const { libnut } = require("@nut-tree-fork/libnut/dist/import_libnut");
 
 // The built directory structure
 //
@@ -309,18 +313,13 @@ ipcMain.handle("mouse-scroll", async (_event, deltaX: number, deltaY: number) =>
   try {
     const stepsX = Math.trunc(deltaX);
     const stepsY = Math.trunc(deltaY);
-
-    if (stepsY < 0) {
-      await mouse.scrollUp(Math.abs(stepsY));
-    } else if (stepsY > 0) {
-      await mouse.scrollDown(stepsY);
+    if (stepsX === 0 && stepsY === 0) {
+      return { success: true };
     }
 
-    if (stepsX < 0) {
-      await mouse.scrollLeft(Math.abs(stepsX));
-    } else if (stepsX > 0) {
-      await mouse.scrollRight(stepsX);
-    }
+    // libnut uses positive Y for wheel-up, while the renderer uses
+    // positive Y for content-down to match DOM WheelEvent semantics.
+    libnut.scrollMouse(stepsX, -stepsY);
 
     return { success: true };
   } catch (error) {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -38,6 +38,9 @@ contextBridge.exposeInMainWorld('mouseSimulator', {
   buttonToggle: (button: string, down: boolean) => {
     return ipcRenderer.invoke('mouse-button-toggle', button, down)
   },
+  scrollMouse: (deltaX: number, deltaY: number) => {
+    return ipcRenderer.invoke('mouse-scroll', deltaX, deltaY)
+  },
 })
 
 // --------- Preload scripts loading ---------

--- a/src/components/AxisMappingPanel.tsx
+++ b/src/components/AxisMappingPanel.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { GamepadState } from '../hooks/useGamepad'
-import { GamepadMapping, StickDirection } from '../hooks/useGamepadMapping'
+import { GamepadMapping, StickDirection, StickMappingType } from '../hooks/useGamepadMapping'
 import { getStickDirection, getStickAxes } from '../utils/stickDirection'
 import { DIRECTION_LABELS } from '../constants/directionLabels'
 import {
@@ -19,7 +19,7 @@ interface AxisMappingPanelProps {
   stickIndex: number
   direction: StickDirection
   editingAxis: { gamepadIndex: number; stickIndex: number; direction: StickDirection } | null
-  onSetAxisMapping: (stickIndex: number, direction: StickDirection, key: string, label: string, threshold: number, type?: 'hotkey' | 'mouse', sensitivity?: number, acceleration?: number, invertX?: boolean, invertY?: boolean) => void
+  onSetAxisMapping: (stickIndex: number, direction: StickDirection, key: string, label: string, threshold: number, type?: StickMappingType, sensitivity?: number, acceleration?: number, invertX?: boolean, invertY?: boolean) => void
   onRemoveAxisMapping: (stickIndex: number, direction: StickDirection) => void
   onSetEditingAxis: (value: { gamepadIndex: number; stickIndex: number; direction: StickDirection } | null) => void
 }
@@ -229,4 +229,3 @@ export function AxisMappingPanel({
     </div>
   )
 }
-

--- a/src/components/KeyMappingSelector.tsx
+++ b/src/components/KeyMappingSelector.tsx
@@ -58,32 +58,35 @@ export function KeyMappingSelector({
       }
     }
 
+    const getCurrentMappingItem = () =>
+      containerRef.current?.closest('.button-mapping-item')
+
+    const isEventInsideCurrentMappingItem = (target: EventTarget | null) => {
+      const mappingItem = getCurrentMappingItem()
+      return !!(mappingItem && target instanceof HTMLElement && mappingItem.contains(target))
+    }
+
+    const isInteractiveElement = (target: HTMLElement) => (
+      target.tagName === 'BUTTON' ||
+      target.closest('button') !== null ||
+      target.tagName === 'A' ||
+      target.closest('a') !== null ||
+      target.closest('.btn-map') !== null ||
+      target.closest('.btn-revert') !== null ||
+      target.closest('.btn-remove') !== null ||
+      target.closest('.btn-remove-small') !== null ||
+      target.closest('.btn-edit') !== null
+    )
+
     const handleMouseDown = (e: MouseEvent) => {
       if (isEditing && containerRef.current) {
-        // Only handle clicks within the current ButtonMappingPanel
-        const buttonMappingPanel = containerRef.current.closest('.button-mapping-item')
-        if (!buttonMappingPanel) {
-          return
-        }
-
         const target = e.target as HTMLElement
-        // Validate click is within the current ButtonMappingPanel
-        if (!buttonMappingPanel.contains(target)) {
+        if (!isEventInsideCurrentMappingItem(target)) {
           return
         }
 
         // Ignore clicks on interactive elements (buttons, links, etc.)
-        if (
-          target.tagName === 'BUTTON' ||
-          target.closest('button') !== null ||
-          target.tagName === 'A' ||
-          target.closest('a') !== null ||
-          target.closest('.btn-map') !== null ||
-          target.closest('.btn-revert') !== null ||
-          target.closest('.btn-remove') !== null ||
-          target.closest('.btn-remove-small') !== null ||
-          target.closest('.btn-edit') !== null
-        ) {
+        if (isInteractiveElement(target)) {
           return // Don't capture clicks on buttons/links
         }
 
@@ -109,14 +112,52 @@ export function KeyMappingSelector({
       }
     }
 
+    const handleWheel = (e: WheelEvent) => {
+      if (!isEditing || !containerRef.current) {
+        return
+      }
+
+      const target = e.target as HTMLElement
+      if (!isEventInsideCurrentMappingItem(target) || isInteractiveElement(target)) {
+        return
+      }
+
+      e.preventDefault()
+      e.stopPropagation()
+
+      let key: string
+      let label: string
+      if (Math.abs(e.deltaX) > Math.abs(e.deltaY)) {
+        if (e.deltaX > 0) {
+          key = 'MouseWheelRight'
+          label = 'Wheel Right'
+        } else {
+          key = 'MouseWheelLeft'
+          label = 'Wheel Left'
+        }
+      } else if (e.deltaY > 0) {
+        key = 'MouseWheelDown'
+        label = 'Wheel Down'
+      } else if (e.deltaY < 0) {
+        key = 'MouseWheelUp'
+        label = 'Wheel Up'
+      } else {
+        return
+      }
+
+      onKeyPress(key, label)
+    }
+
     if (isEditing) {
       window.addEventListener('keydown', handleKeyDown)
       window.addEventListener('mousedown', handleMouseDown, true) // Use capture phase
+      window.addEventListener('wheel', handleWheel, { capture: true, passive: false })
     }
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('mousedown', handleMouseDown, true)
+      window.removeEventListener('wheel', handleWheel, true)
     }
   }, [isEditing, onKeyPress])
 
@@ -151,4 +192,3 @@ export function KeyMappingSelector({
     </div>
   )
 }
-

--- a/src/components/MappingPanel.tsx
+++ b/src/components/MappingPanel.tsx
@@ -1,5 +1,9 @@
 import { GamepadState } from "../hooks/useGamepad";
-import { GamepadMapping, StickDirection } from "../hooks/useGamepadMapping";
+import {
+  GamepadMapping,
+  StickDirection,
+  StickMappingType,
+} from "../hooks/useGamepadMapping";
 import { ButtonMappingPanel } from "./ButtonMappingPanel";
 import { StickMappingPanel } from "./StickMappingPanel";
 import { DpadMappingPanel } from "./DpadMappingPanel";
@@ -19,7 +23,7 @@ interface MappingPanelProps {
     key: string,
     label: string,
     threshold: number,
-    type?: "hotkey" | "mouse",
+    type?: StickMappingType,
     sensitivity?: number,
     acceleration?: number,
     invertX?: boolean,

--- a/src/components/StickHotkeyMode.tsx
+++ b/src/components/StickHotkeyMode.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from 'react'
 import { GamepadState } from '../hooks/useGamepad'
-import { GamepadMapping, StickDirection } from '../hooks/useGamepadMapping'
+import { GamepadMapping, StickDirection, StickMappingType } from '../hooks/useGamepadMapping'
 import { MappingActions } from './MappingPanel'
 import { KeyMappingSelector } from './KeyMappingSelector'
 import { getStickDirection, getStickAxes } from '../utils/stickDirection'
@@ -13,7 +13,7 @@ interface StickHotkeyModeProps {
   mapping?: GamepadMapping
   stickIndex: number
   editingAxis: { gamepadIndex: number; stickIndex: number; direction: StickDirection } | null
-  onSetAxisMapping: (stickIndex: number, direction: StickDirection, key: string, label: string, threshold: number, type?: 'hotkey' | 'mouse', sensitivity?: number, acceleration?: number, invertX?: boolean, invertY?: boolean) => void
+  onSetAxisMapping: (stickIndex: number, direction: StickDirection, key: string, label: string, threshold: number, type?: StickMappingType, sensitivity?: number, acceleration?: number, invertX?: boolean, invertY?: boolean) => void
   onRemoveAxisMapping: (stickIndex: number, direction: StickDirection) => void
   onSetEditingAxis: (value: { gamepadIndex: number; stickIndex: number; direction: StickDirection } | null) => void
   onRemoveAllMappings: (stickIndex: number) => void
@@ -201,4 +201,3 @@ export function StickHotkeyMode({
     </>
   )
 }
-

--- a/src/components/StickMappingPanel.tsx
+++ b/src/components/StickMappingPanel.tsx
@@ -1,8 +1,13 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { GamepadState } from "../hooks/useGamepad";
-import { GamepadMapping, StickDirection } from "../hooks/useGamepadMapping";
+import {
+  GamepadMapping,
+  StickDirection,
+  StickMappingType,
+} from "../hooks/useGamepadMapping";
 import { StickHotkeyMode } from "./StickHotkeyMode";
 import { StickMouseMode } from "./StickMouseMode";
+import { StickScrollMode } from "./StickScrollMode";
 import { KeyMappingSelector } from "./KeyMappingSelector";
 import { MappingActions } from "./MappingPanel";
 import { getSticks, getButtonConfig } from "../constants/controllerMappings";
@@ -24,7 +29,7 @@ interface StickMappingPanelProps {
     key: string,
     label: string,
     threshold: number,
-    type?: "hotkey" | "mouse",
+    type?: StickMappingType,
     sensitivity?: number,
     acceleration?: number,
     invertX?: boolean,
@@ -58,23 +63,28 @@ export function StickMappingPanel({
   onRemoveButtonMapping,
   onSetEditingButton,
 }: StickMappingPanelProps) {
-  const [mappingType, setMappingType] = useState<"hotkey" | "mouse">("hotkey");
-  const previousMappingTypeRef = useRef<"hotkey" | "mouse" | null>(null);
+  const [mappingType, setMappingType] = useState<StickMappingType>("hotkey");
+  const previousMappingTypeRef = useRef<StickMappingType | null>(null);
 
   const stickMappings =
     mapping?.axisMappings.filter((m) => m.stickIndex === stickIndex) || [];
   const mouseMapping = stickMappings.find((m) => m.type === "mouse");
+  const scrollMapping = stickMappings.find((m) => m.type === "scroll");
   const isMouseMode = mouseMapping !== undefined || mappingType === "mouse";
+  const isScrollMode = scrollMapping !== undefined || mappingType === "scroll";
 
   // Sync mapping type with existing mappings
   useEffect(() => {
     if (mouseMapping) {
       setMappingType("mouse");
       previousMappingTypeRef.current = "mouse";
+    } else if (scrollMapping) {
+      setMappingType("scroll");
+      previousMappingTypeRef.current = "scroll";
     } else {
       setMappingType("hotkey");
     }
-  }, [mouseMapping]);
+  }, [mouseMapping, scrollMapping]);
 
   const removeAllStickMappings = (stickIndex: number) => {
     const stickMappings =
@@ -228,12 +238,13 @@ export function StickMappingPanel({
         <label>Mapping Mode:</label>
         <div className="mode-buttons">
           <button
-            className={`mode-button ${!isMouseMode ? "active" : ""}`}
+            className={`mode-button ${!isMouseMode && !isScrollMode ? "active" : ""}`}
             onClick={() => {
-              // Switch to hotkey mode - remove mouse mapping if exists
-              if (mouseMapping) {
-                onRemoveAxisMapping(stickIndex, mouseMapping.direction);
-              }
+              stickMappings.forEach((m) => {
+                if (m.type !== "hotkey") {
+                  onRemoveAxisMapping(stickIndex, m.direction);
+                }
+              });
               // Track that we're switching modes
               previousMappingTypeRef.current = mappingType;
               // Always set to hotkey mode and clear editing state
@@ -248,9 +259,7 @@ export function StickMappingPanel({
           <button
             className={`mode-button ${isMouseMode ? "active" : ""}`}
             onClick={() => {
-              // Switch to mouse mode - remove all hotkey mappings for this stick first
               if (!mouseMapping) {
-                // Remove all existing hotkey mappings for this stick
                 stickMappings.forEach((m) => {
                   if (m.type !== "mouse") {
                     onRemoveAxisMapping(stickIndex, m.direction);
@@ -268,10 +277,37 @@ export function StickMappingPanel({
           >
             Mouse Control
           </button>
+          <button
+            className={`mode-button ${isScrollMode ? "active" : ""}`}
+            onClick={() => {
+              if (!scrollMapping) {
+                stickMappings.forEach((m) => {
+                  if (m.type !== "scroll") {
+                    onRemoveAxisMapping(stickIndex, m.direction);
+                  }
+                });
+                previousMappingTypeRef.current = mappingType;
+                setMappingType("scroll");
+                if (editingAxis?.stickIndex === stickIndex) {
+                  onSetEditingAxis(null);
+                }
+              }
+            }}
+          >
+            Scroll Control
+          </button>
         </div>
       </div>
 
-      {isMouseMode ? (
+      {isScrollMode ? (
+        <StickScrollMode
+          mapping={mapping}
+          stickIndex={stickIndex}
+          onSetAxisMapping={onSetAxisMapping}
+          onRemoveAxisMapping={onRemoveAxisMapping}
+          previousMappingType={previousMappingTypeRef.current}
+        />
+      ) : isMouseMode ? (
         <StickMouseMode
           mapping={mapping}
           stickIndex={stickIndex}

--- a/src/components/StickScrollMode.tsx
+++ b/src/components/StickScrollMode.tsx
@@ -3,14 +3,14 @@ import { GamepadMapping, StickDirection, StickMappingType } from '../hooks/useGa
 import { MappingActions } from './MappingPanel'
 import {
   DEFAULT_STICK_THRESHOLD_MOUSE,
-  DEFAULT_MOUSE_SENSITIVITY,
-  DEFAULT_MOUSE_ACCELERATION,
-  DEFAULT_MOUSE_INVERT_X,
-  DEFAULT_MOUSE_INVERT_Y,
+  DEFAULT_SCROLL_SENSITIVITY,
+  DEFAULT_SCROLL_ACCELERATION,
+  DEFAULT_SCROLL_INVERT_X,
+  DEFAULT_SCROLL_INVERT_Y,
 } from '../constants/defaults'
 import './MappingPanel.css'
 
-interface StickMouseModeProps {
+interface StickScrollModeProps {
   mapping?: GamepadMapping
   stickIndex: number
   onSetAxisMapping: (stickIndex: number, direction: StickDirection, key: string, label: string, threshold: number, type?: StickMappingType, sensitivity?: number, acceleration?: number, invertX?: boolean, invertY?: boolean) => void
@@ -18,20 +18,20 @@ interface StickMouseModeProps {
   previousMappingType: StickMappingType | null
 }
 
-export function StickMouseMode({
+export function StickScrollMode({
   mapping,
   stickIndex,
   onSetAxisMapping,
   onRemoveAxisMapping,
   previousMappingType,
-}: StickMouseModeProps) {
+}: StickScrollModeProps) {
   const [threshold, setThreshold] = useState(DEFAULT_STICK_THRESHOLD_MOUSE)
-  const [sensitivity, setSensitivity] = useState(DEFAULT_MOUSE_SENSITIVITY)
-  const [acceleration, setAcceleration] = useState(DEFAULT_MOUSE_ACCELERATION)
-  const [invertX, setInvertX] = useState(DEFAULT_MOUSE_INVERT_X)
-  const [invertY, setInvertY] = useState(DEFAULT_MOUSE_INVERT_Y)
+  const [sensitivity, setSensitivity] = useState(DEFAULT_SCROLL_SENSITIVITY)
+  const [acceleration, setAcceleration] = useState(DEFAULT_SCROLL_ACCELERATION)
+  const [invertX, setInvertX] = useState(DEFAULT_SCROLL_INVERT_X)
+  const [invertY, setInvertY] = useState(DEFAULT_SCROLL_INVERT_Y)
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false)
-  const originalMouseMappingRef = useRef<{
+  const originalScrollMappingRef = useRef<{
     threshold: number
     sensitivity: number
     acceleration: number
@@ -40,84 +40,77 @@ export function StickMouseMode({
   } | null>(null)
 
   const stickMappings = mapping?.axisMappings.filter(m => m.stickIndex === stickIndex) || []
-  const mouseMapping = stickMappings.find(m => m.type === 'mouse')
+  const scrollMapping = stickMappings.find(m => m.type === 'scroll')
 
-  // Sync state with mouse mapping when it changes
   useEffect(() => {
-    if (mouseMapping) {
+    if (scrollMapping) {
       const values = {
-        threshold: mouseMapping.threshold,
-        sensitivity: mouseMapping.sensitivity ?? DEFAULT_MOUSE_SENSITIVITY,
-        acceleration: mouseMapping.acceleration ?? DEFAULT_MOUSE_ACCELERATION,
-        invertX: mouseMapping.invertX ?? DEFAULT_MOUSE_INVERT_X,
-        invertY: mouseMapping.invertY ?? DEFAULT_MOUSE_INVERT_Y,
+        threshold: scrollMapping.threshold,
+        sensitivity: scrollMapping.sensitivity ?? DEFAULT_SCROLL_SENSITIVITY,
+        acceleration: scrollMapping.acceleration ?? DEFAULT_SCROLL_ACCELERATION,
+        invertX: scrollMapping.invertX ?? DEFAULT_SCROLL_INVERT_X,
+        invertY: scrollMapping.invertY ?? DEFAULT_SCROLL_INVERT_Y,
       }
       setThreshold(values.threshold)
       setSensitivity(values.sensitivity)
       setAcceleration(values.acceleration)
       setInvertX(values.invertX)
       setInvertY(values.invertY)
-      originalMouseMappingRef.current = values
+      originalScrollMappingRef.current = values
       setHasUnsavedChanges(false)
     } else {
-      // Initialize defaults
       const values = {
         threshold: DEFAULT_STICK_THRESHOLD_MOUSE,
-        sensitivity: DEFAULT_MOUSE_SENSITIVITY,
-        acceleration: DEFAULT_MOUSE_ACCELERATION,
-        invertX: DEFAULT_MOUSE_INVERT_X,
-        invertY: DEFAULT_MOUSE_INVERT_Y,
+        sensitivity: DEFAULT_SCROLL_SENSITIVITY,
+        acceleration: DEFAULT_SCROLL_ACCELERATION,
+        invertX: DEFAULT_SCROLL_INVERT_X,
+        invertY: DEFAULT_SCROLL_INVERT_Y,
       }
       setThreshold(values.threshold)
       setSensitivity(values.sensitivity)
       setAcceleration(values.acceleration)
       setInvertX(values.invertX)
       setInvertY(values.invertY)
-      originalMouseMappingRef.current = null
+      originalScrollMappingRef.current = null
     }
-  }, [mouseMapping])
+  }, [scrollMapping])
 
-  // Check for changes
   useEffect(() => {
-    // Check if mapping type changed (mode switch from hotkey to mouse)
-    const mappingTypeChanged = previousMappingType === 'hotkey'
-    
-    if (mouseMapping) {
-      // Compare current values with saved mapping
-      const hasChanges = 
-        Math.abs(threshold - mouseMapping.threshold) > 0.01 ||
-        Math.abs((sensitivity ?? DEFAULT_MOUSE_SENSITIVITY) - (mouseMapping.sensitivity ?? DEFAULT_MOUSE_SENSITIVITY)) > 0.01 ||
-        Math.abs((acceleration ?? DEFAULT_MOUSE_ACCELERATION) - (mouseMapping.acceleration ?? DEFAULT_MOUSE_ACCELERATION)) > 0.01 ||
-        (invertX ?? DEFAULT_MOUSE_INVERT_X) !== (mouseMapping.invertX ?? DEFAULT_MOUSE_INVERT_X) ||
-        (invertY ?? DEFAULT_MOUSE_INVERT_Y) !== (mouseMapping.invertY ?? DEFAULT_MOUSE_INVERT_Y)
+    const mappingTypeChanged = previousMappingType !== null && previousMappingType !== 'scroll'
+
+    if (scrollMapping) {
+      const hasChanges =
+        Math.abs(threshold - scrollMapping.threshold) > 0.01 ||
+        Math.abs((sensitivity ?? DEFAULT_SCROLL_SENSITIVITY) - (scrollMapping.sensitivity ?? DEFAULT_SCROLL_SENSITIVITY)) > 0.01 ||
+        Math.abs((acceleration ?? DEFAULT_SCROLL_ACCELERATION) - (scrollMapping.acceleration ?? DEFAULT_SCROLL_ACCELERATION)) > 0.01 ||
+        (invertX ?? DEFAULT_SCROLL_INVERT_X) !== (scrollMapping.invertX ?? DEFAULT_SCROLL_INVERT_X) ||
+        (invertY ?? DEFAULT_SCROLL_INVERT_Y) !== (scrollMapping.invertY ?? DEFAULT_SCROLL_INVERT_Y)
       setHasUnsavedChanges(hasChanges)
     } else {
-      // New mapping - show buttons if mapping type changed OR if values differ from defaults
-      const valuesDifferFromDefaults = 
+      const valuesDifferFromDefaults =
         Math.abs(threshold - DEFAULT_STICK_THRESHOLD_MOUSE) > 0.01 ||
-        Math.abs((sensitivity ?? DEFAULT_MOUSE_SENSITIVITY) - DEFAULT_MOUSE_SENSITIVITY) > 0.01 ||
-        Math.abs((acceleration ?? DEFAULT_MOUSE_ACCELERATION) - DEFAULT_MOUSE_ACCELERATION) > 0.01 ||
-        (invertX ?? DEFAULT_MOUSE_INVERT_X) !== DEFAULT_MOUSE_INVERT_X ||
-        (invertY ?? DEFAULT_MOUSE_INVERT_Y) !== DEFAULT_MOUSE_INVERT_Y
+        Math.abs((sensitivity ?? DEFAULT_SCROLL_SENSITIVITY) - DEFAULT_SCROLL_SENSITIVITY) > 0.01 ||
+        Math.abs((acceleration ?? DEFAULT_SCROLL_ACCELERATION) - DEFAULT_SCROLL_ACCELERATION) > 0.01 ||
+        (invertX ?? DEFAULT_SCROLL_INVERT_X) !== DEFAULT_SCROLL_INVERT_X ||
+        (invertY ?? DEFAULT_SCROLL_INVERT_Y) !== DEFAULT_SCROLL_INVERT_Y
       setHasUnsavedChanges(mappingTypeChanged || valuesDifferFromDefaults)
     }
-  }, [threshold, sensitivity, acceleration, invertX, invertY, mouseMapping, previousMappingType])
+  }, [threshold, sensitivity, acceleration, invertX, invertY, scrollMapping, previousMappingType])
 
   const revertChanges = useCallback(() => {
-    if (originalMouseMappingRef.current) {
-      setThreshold(originalMouseMappingRef.current.threshold)
-      setSensitivity(originalMouseMappingRef.current.sensitivity)
-      setAcceleration(originalMouseMappingRef.current.acceleration)
-      setInvertX(originalMouseMappingRef.current.invertX)
-      setInvertY(originalMouseMappingRef.current.invertY)
+    if (originalScrollMappingRef.current) {
+      setThreshold(originalScrollMappingRef.current.threshold)
+      setSensitivity(originalScrollMappingRef.current.sensitivity)
+      setAcceleration(originalScrollMappingRef.current.acceleration)
+      setInvertX(originalScrollMappingRef.current.invertX)
+      setInvertY(originalScrollMappingRef.current.invertY)
       setHasUnsavedChanges(false)
     } else {
-      // Revert to defaults for new mapping
       setThreshold(DEFAULT_STICK_THRESHOLD_MOUSE)
-      setSensitivity(DEFAULT_MOUSE_SENSITIVITY)
-      setAcceleration(DEFAULT_MOUSE_ACCELERATION)
-      setInvertX(DEFAULT_MOUSE_INVERT_X)
-      setInvertY(DEFAULT_MOUSE_INVERT_Y)
+      setSensitivity(DEFAULT_SCROLL_SENSITIVITY)
+      setAcceleration(DEFAULT_SCROLL_ACCELERATION)
+      setInvertX(DEFAULT_SCROLL_INVERT_X)
+      setInvertY(DEFAULT_SCROLL_INVERT_Y)
       setHasUnsavedChanges(false)
     }
   }, [])
@@ -137,7 +130,7 @@ export function StickMouseMode({
         <span>{threshold.toFixed(2)}</span>
       </div>
       <div className="threshold-control">
-        <label>Sensitivity:</label>
+        <label>Speed:</label>
         <input
           type="range"
           min="0.1"
@@ -161,7 +154,7 @@ export function StickMouseMode({
         <span>{acceleration.toFixed(2)}</span>
       </div>
       <div className="threshold-control">
-        <label>Invert X:</label>
+        <label>Invert Horizontal:</label>
         <input
           type="checkbox"
           checked={invertX}
@@ -169,20 +162,20 @@ export function StickMouseMode({
         />
       </div>
       <div className="threshold-control">
-        <label>Invert Y:</label>
+        <label>Invert Vertical:</label>
         <input
           type="checkbox"
           checked={invertY}
           onChange={(e) => setInvertY(e.target.checked)}
         />
       </div>
-      
+
       <MappingActions
         hasUnsavedChanges={hasUnsavedChanges}
         onApplyChanges={() => {
-          onSetAxisMapping(stickIndex, 'up', 'Mouse', 'Mouse', threshold, 'mouse', sensitivity, acceleration, invertX, invertY)
+          onSetAxisMapping(stickIndex, 'up', 'Scroll', 'Scroll', threshold, 'scroll', sensitivity, acceleration, invertX, invertY)
           setHasUnsavedChanges(false)
-          originalMouseMappingRef.current = {
+          originalScrollMappingRef.current = {
             threshold,
             sensitivity,
             acceleration,
@@ -192,13 +185,13 @@ export function StickMouseMode({
         }}
         onRevertChanges={revertChanges}
         onRemoveMapping={() => {
-          if (mouseMapping) {
-            onRemoveAxisMapping(stickIndex, mouseMapping.direction)
+          if (scrollMapping) {
+            onRemoveAxisMapping(stickIndex, scrollMapping.direction)
           }
           setHasUnsavedChanges(false)
-          originalMouseMappingRef.current = null
+          originalScrollMappingRef.current = null
         }}
-        showRemove={!!(mouseMapping)}
+        showRemove={!!(scrollMapping)}
       />
     </div>
   )

--- a/src/constants/defaults.ts
+++ b/src/constants/defaults.ts
@@ -13,6 +13,12 @@ export const DEFAULT_MOUSE_ACCELERATION = 1.0
 export const DEFAULT_MOUSE_INVERT_X = false
 export const DEFAULT_MOUSE_INVERT_Y = false
 
+// Scroll control defaults
+export const DEFAULT_SCROLL_SENSITIVITY = 1.0
+export const DEFAULT_SCROLL_ACCELERATION = 1.0
+export const DEFAULT_SCROLL_INVERT_X = false
+export const DEFAULT_SCROLL_INVERT_Y = false
+
 // Button detection defaults
 export const DEFAULT_DRIFT_THRESHOLD = 0.1
 
@@ -33,4 +39,3 @@ export const SENSITIVITY_STEP = 0.1
 export const MIN_ACCELERATION = 0.0
 export const MAX_ACCELERATION = 2.0
 export const ACCELERATION_STEP = 0.1
-

--- a/src/hooks/useGamepadMapping.ts
+++ b/src/hooks/useGamepadMapping.ts
@@ -63,6 +63,7 @@ export interface GamepadMapping {
 }
 
 const STORAGE_KEY = "gamepad-mappings";
+const SCROLL_STEPS_PER_SECOND = 60;
 
 export function useGamepadMapping(gamepads: GamepadState[]) {
   const [mappings, setMappings] = useState<GamepadMapping[]>([]);
@@ -376,10 +377,10 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
   const previousAxisStatesRef = useRef<Map<string, boolean>>(new Map());
   // Track pending mouse movements to prevent queuing (which causes drift)
   const pendingMouseMovementsRef = useRef<Set<string>>(new Set());
-  const pendingMouseScrollsRef = useRef<Set<string>>(new Set());
   const scrollRemainderRef = useRef<Map<string, { x: number; y: number }>>(
     new Map()
   );
+  const lastScrollUpdateTimeRef = useRef<Map<string, number>>(new Map());
   // Track when each stick started moving for time-based acceleration
   const stickMovementStartTimeRef = useRef<Map<string, number>>(new Map());
 
@@ -401,8 +402,8 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
   };
 
   const sendMouseScroll = useCallback(
-    (deltaX: number, deltaY: number, stateKey: string) => {
-      if (!window.mouseSimulator || pendingMouseScrollsRef.current.has(stateKey)) {
+    (deltaX: number, deltaY: number) => {
+      if (!window.mouseSimulator) {
         return;
       }
 
@@ -412,16 +413,9 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         return;
       }
 
-      pendingMouseScrollsRef.current.add(stateKey);
-      window.mouseSimulator
-        .scrollMouse(stepsX, stepsY)
-        .then(() => {
-          pendingMouseScrollsRef.current.delete(stateKey);
-        })
-        .catch((err) => {
-          console.error("Error scrolling mouse:", err);
-          pendingMouseScrollsRef.current.delete(stateKey);
-        });
+      void window.mouseSimulator.scrollMouse(stepsX, stepsY).catch((err) => {
+        console.error("Error scrolling mouse:", err);
+      });
     },
     []
   );
@@ -432,7 +426,7 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
       if (!delta) {
         return;
       }
-      sendMouseScroll(delta.deltaX, delta.deltaY, stateKey);
+      sendMouseScroll(delta.deltaX, delta.deltaY);
     },
     [sendMouseScroll]
   );
@@ -749,6 +743,7 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         if (inDeadzone) {
           stickMovementStartTimeRef.current.delete(scrollStateKey);
           scrollRemainderRef.current.delete(scrollStateKey);
+          lastScrollUpdateTimeRef.current.delete(scrollStateKey);
           return;
         }
 
@@ -757,13 +752,21 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         const acceleration =
           scrollMapping.acceleration ?? DEFAULT_SCROLL_ACCELERATION;
 
-        const now = Date.now();
+        const now = performance.now();
         if (!stickMovementStartTimeRef.current.has(scrollStateKey)) {
           stickMovementStartTimeRef.current.set(scrollStateKey, now);
         }
+        const previousUpdateTime =
+          lastScrollUpdateTimeRef.current.get(scrollStateKey) ??
+          now - 1000 / SCROLL_STEPS_PER_SECOND;
+        lastScrollUpdateTimeRef.current.set(scrollStateKey, now);
         const movementStartTime =
           stickMovementStartTimeRef.current.get(scrollStateKey)!;
         const movementDurationSeconds = (now - movementStartTime) / 1000;
+        const elapsedSeconds = Math.min(
+          Math.max((now - previousUpdateTime) / 1000, 0),
+          0.05
+        );
 
         let normalizedX = 0;
         let normalizedY = 0;
@@ -797,19 +800,26 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         ) {
           stickMovementStartTimeRef.current.delete(scrollStateKey);
           scrollRemainderRef.current.delete(scrollStateKey);
-          return;
-        }
-
-        if (pendingMouseScrollsRef.current.has(scrollStateKey)) {
+          lastScrollUpdateTimeRef.current.delete(scrollStateKey);
           return;
         }
 
         const remainder =
           scrollRemainderRef.current.get(scrollStateKey) ?? { x: 0, y: 0 };
         const nextX =
-          remainder.x + normalizedX * sensitivity * accelerationMultiplier;
+          remainder.x +
+          normalizedX *
+            sensitivity *
+            accelerationMultiplier *
+            elapsedSeconds *
+            SCROLL_STEPS_PER_SECOND;
         const nextY =
-          remainder.y + normalizedY * sensitivity * accelerationMultiplier;
+          remainder.y +
+          normalizedY *
+            sensitivity *
+            accelerationMultiplier *
+            elapsedSeconds *
+            SCROLL_STEPS_PER_SECOND;
         const stepsX = nextX < 0 ? Math.ceil(nextX) : Math.floor(nextX);
         const stepsY = nextY < 0 ? Math.ceil(nextY) : Math.floor(nextY);
 
@@ -818,7 +828,7 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
           y: nextY - stepsY,
         });
 
-        sendMouseScroll(stepsX, stepsY, scrollStateKey);
+        sendMouseScroll(stepsX, stepsY);
       });
 
       // Process hotkey mappings (skip if a continuous mode is enabled for that stick)

--- a/src/hooks/useGamepadMapping.ts
+++ b/src/hooks/useGamepadMapping.ts
@@ -11,6 +11,10 @@ import {
   DEFAULT_MOUSE_ACCELERATION,
   DEFAULT_MOUSE_INVERT_X,
   DEFAULT_MOUSE_INVERT_Y,
+  DEFAULT_SCROLL_ACCELERATION,
+  DEFAULT_SCROLL_INVERT_X,
+  DEFAULT_SCROLL_INVERT_Y,
+  DEFAULT_SCROLL_SENSITIVITY,
   DEFAULT_STICK_MAPPING_TYPE,
 } from "../constants/defaults";
 
@@ -30,7 +34,7 @@ export type StickDirection =
   | "down-left"
   | "down-right";
 
-export type StickMappingType = "hotkey" | "mouse";
+export type StickMappingType = "hotkey" | "mouse" | "scroll";
 
 export interface AxisMapping {
   stickIndex: number; // 0 for left stick, 1 for right stick
@@ -38,11 +42,11 @@ export interface AxisMapping {
   key: string;
   label: string;
   threshold: number;
-  type: StickMappingType; // 'hotkey' for 8 directions, 'mouse' for mouse control
-  sensitivity?: number; // For mouse control (0.1 - 10.0)
-  acceleration?: number; // For mouse control (0.0 - 2.0)
-  invertX?: boolean; // For mouse control
-  invertY?: boolean; // For mouse control
+  type: StickMappingType; // 'hotkey' for 8 directions, 'mouse' for mouse control, 'scroll' for wheel control
+  sensitivity?: number; // For mouse/scroll control (0.1 - 10.0)
+  acceleration?: number; // For mouse/scroll control (0.0 - 2.0)
+  invertX?: boolean; // For mouse/scroll control
+  invertY?: boolean; // For mouse/scroll control
 }
 
 export interface DpadMapping {
@@ -126,6 +130,10 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
     return mapping.axisMappings.filter((m) => m.type === "mouse");
   }, []);
 
+  const getScrollMappings = useCallback((mapping: GamepadMapping) => {
+    return mapping.axisMappings.filter((m) => m.type === "scroll");
+  }, []);
+
   const setButtonMapping = useCallback(
     (gamepadIndex: number, buttonIndex: number, key: string, label: string) => {
       setMappings((prev) => {
@@ -187,29 +195,29 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
           updated.push(mapping);
         }
 
-        if (type === "mouse") {
-          // For mouse mode, there's only one mapping per stick (direction doesn't matter)
-          const existingMouseMapping = mapping.axisMappings.find(
-            (m) => m.stickIndex === stickIndex && m.type === "mouse"
+        if (type === "mouse" || type === "scroll") {
+          // For continuous modes, there's only one mapping per stick (direction doesn't matter)
+          const existingContinuousMapping = mapping.axisMappings.find(
+            (m) => m.stickIndex === stickIndex && m.type === type
           );
-          if (existingMouseMapping) {
-            existingMouseMapping.threshold = threshold;
-            existingMouseMapping.sensitivity = sensitivity;
-            existingMouseMapping.acceleration = acceleration;
-            existingMouseMapping.invertX = invertX;
-            existingMouseMapping.invertY = invertY;
+          if (existingContinuousMapping) {
+            existingContinuousMapping.threshold = threshold;
+            existingContinuousMapping.sensitivity = sensitivity;
+            existingContinuousMapping.acceleration = acceleration;
+            existingContinuousMapping.invertX = invertX;
+            existingContinuousMapping.invertY = invertY;
           } else {
-            // Remove all hotkey mappings for this stick when adding mouse mapping
+            // Remove all other mappings for this stick when adding a continuous mapping
             mapping.axisMappings = mapping.axisMappings.filter(
-              (m) => !(m.stickIndex === stickIndex && m.type === "hotkey")
+              (m) => m.stickIndex !== stickIndex
             );
             mapping.axisMappings.push({
               stickIndex,
               direction: "up",
-              key: "Mouse",
-              label: "Mouse",
+              key: type === "mouse" ? "Mouse" : "Scroll",
+              label: type === "mouse" ? "Mouse" : "Scroll",
               threshold,
-              type: "mouse",
+              type,
               sensitivity,
               acceleration,
               invertX,
@@ -229,9 +237,9 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
             existingAxisMapping.label = label;
             existingAxisMapping.threshold = threshold;
           } else {
-            // Remove mouse mapping if exists when adding hotkey mapping
+            // Remove continuous mapping if exists when adding hotkey mapping
             mapping.axisMappings = mapping.axisMappings.filter(
-              (m) => !(m.stickIndex === stickIndex && m.type === "mouse")
+              (m) => !(m.stickIndex === stickIndex && m.type !== "hotkey")
             );
             mapping.axisMappings.push({
               stickIndex,
@@ -368,8 +376,66 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
   const previousAxisStatesRef = useRef<Map<string, boolean>>(new Map());
   // Track pending mouse movements to prevent queuing (which causes drift)
   const pendingMouseMovementsRef = useRef<Set<string>>(new Set());
+  const pendingMouseScrollsRef = useRef<Set<string>>(new Set());
+  const scrollRemainderRef = useRef<Map<string, { x: number; y: number }>>(
+    new Map()
+  );
   // Track when each stick started moving for time-based acceleration
   const stickMovementStartTimeRef = useRef<Map<string, number>>(new Map());
+
+  const isMouseWheelKey = (key: string) => key.startsWith("MouseWheel");
+
+  const getMouseWheelDelta = (key: string, amount: number = 1) => {
+    switch (key) {
+      case "MouseWheelUp":
+        return { deltaX: 0, deltaY: -amount };
+      case "MouseWheelDown":
+        return { deltaX: 0, deltaY: amount };
+      case "MouseWheelLeft":
+        return { deltaX: -amount, deltaY: 0 };
+      case "MouseWheelRight":
+        return { deltaX: amount, deltaY: 0 };
+      default:
+        return null;
+    }
+  };
+
+  const sendMouseScroll = useCallback(
+    (deltaX: number, deltaY: number, stateKey: string) => {
+      if (!window.mouseSimulator || pendingMouseScrollsRef.current.has(stateKey)) {
+        return;
+      }
+
+      const stepsX = Math.trunc(deltaX);
+      const stepsY = Math.trunc(deltaY);
+      if (stepsX === 0 && stepsY === 0) {
+        return;
+      }
+
+      pendingMouseScrollsRef.current.add(stateKey);
+      window.mouseSimulator
+        .scrollMouse(stepsX, stepsY)
+        .then(() => {
+          pendingMouseScrollsRef.current.delete(stateKey);
+        })
+        .catch((err) => {
+          console.error("Error scrolling mouse:", err);
+          pendingMouseScrollsRef.current.delete(stateKey);
+        });
+    },
+    []
+  );
+
+  const triggerMappedWheelScroll = useCallback(
+    (key: string, stateKey: string, amount: number = 1) => {
+      const delta = getMouseWheelDelta(key, amount);
+      if (!delta) {
+        return;
+      }
+      sendMouseScroll(delta.deltaX, delta.deltaY, stateKey);
+    },
+    [sendMouseScroll]
+  );
 
   // Simulate keyboard key press or mouse button via Electron IPC
   const simulateKeyPress = useCallback(
@@ -406,8 +472,11 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         if (!wasPressed) {
           try {
             let result;
-            // Check if it's a mouse button
-            if (key.startsWith("Mouse")) {
+            if (isMouseWheelKey(key)) {
+              triggerMappedWheelScroll(key, stateKey);
+              result = { success: true };
+            } else if (key.startsWith("Mouse")) {
+              // Check if it's a mouse button
               if (!window.mouseSimulator) {
                 console.warn("Mouse simulator not available");
                 return;
@@ -442,8 +511,10 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         if (wasPressed && holders.size === 0) {
           try {
             let result;
-            // Check if it's a mouse button
-            if (key.startsWith("Mouse")) {
+            if (isMouseWheelKey(key)) {
+              result = { success: true };
+            } else if (key.startsWith("Mouse")) {
+              // Check if it's a mouse button
               if (!window.mouseSimulator) {
                 console.warn("Mouse simulator not available");
                 return;
@@ -471,7 +542,7 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         }
       }
     },
-    []
+    [triggerMappedWheelScroll]
   );
 
   // Check and trigger mappings based on gamepad state
@@ -485,7 +556,13 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         const button = gamepad.buttons[btnMapping.buttonIndex];
         if (button) {
           const stateKey = `gamepad-${gamepad.index}-button-${btnMapping.buttonIndex}`;
-          simulateKeyPress(btnMapping.key, button.pressed, stateKey);
+          if (isMouseWheelKey(btnMapping.key)) {
+            if (button.pressed) {
+              triggerMappedWheelScroll(btnMapping.key, stateKey);
+            }
+          } else {
+            simulateKeyPress(btnMapping.key, button.pressed, stateKey);
+          }
         }
       });
 
@@ -512,14 +589,24 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
             isActive = fallbackDirections.includes(dpadMapping.direction);
           }
 
-          simulateKeyPress(dpadMapping.key, isActive, stateKey);
+          if (isMouseWheelKey(dpadMapping.key)) {
+            if (isActive) {
+              triggerMappedWheelScroll(dpadMapping.key, stateKey);
+            }
+          } else {
+            simulateKeyPress(dpadMapping.key, isActive, stateKey);
+          }
         });
       }
 
       // Process axis mappings - handle both hotkey and mouse control modes
       // Check if mouse mode is enabled for each stick
       const mouseMappings = getMouseMappings(mapping);
-      const sticksWithMouse = new Set(mouseMappings.map((m) => m.stickIndex));
+      const scrollMappings = getScrollMappings(mapping);
+      const sticksWithContinuous = new Set([
+        ...mouseMappings.map((m) => m.stickIndex),
+        ...scrollMappings.map((m) => m.stickIndex),
+      ]);
       const processedMouseSticks = new Set<number>();
 
       // Process mouse mappings first (one per stick)
@@ -636,13 +723,111 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
         }
       });
 
-      // Process hotkey mappings (skip if mouse mode is enabled for that stick)
+      const processedScrollSticks = new Set<number>();
+
+      // Process scroll mappings first (one per stick)
+      scrollMappings.forEach((scrollMapping) => {
+        const stickIndex = scrollMapping.stickIndex;
+        if (processedScrollSticks.has(stickIndex)) {
+          return;
+        }
+        processedScrollSticks.add(stickIndex);
+
+        const { axisXIndex, axisYIndex } = getStickAxes(stickIndex);
+        let stickX = gamepad.axes[axisXIndex] || 0;
+        let stickY = gamepad.axes[axisYIndex] || 0;
+
+        if (scrollMapping.invertX) stickX = -stickX;
+        if (scrollMapping.invertY) stickY = -stickY;
+
+        const absX = Math.abs(stickX);
+        const absY = Math.abs(stickY);
+        const threshold = scrollMapping.threshold;
+        const inDeadzone = absX < threshold && absY < threshold;
+        const scrollStateKey = `gamepad-${gamepad.index}-scroll-${stickIndex}`;
+
+        if (inDeadzone) {
+          stickMovementStartTimeRef.current.delete(scrollStateKey);
+          scrollRemainderRef.current.delete(scrollStateKey);
+          return;
+        }
+
+        const sensitivity =
+          scrollMapping.sensitivity ?? DEFAULT_SCROLL_SENSITIVITY;
+        const acceleration =
+          scrollMapping.acceleration ?? DEFAULT_SCROLL_ACCELERATION;
+
+        const now = Date.now();
+        if (!stickMovementStartTimeRef.current.has(scrollStateKey)) {
+          stickMovementStartTimeRef.current.set(scrollStateKey, now);
+        }
+        const movementStartTime =
+          stickMovementStartTimeRef.current.get(scrollStateKey)!;
+        const movementDurationSeconds = (now - movementStartTime) / 1000;
+
+        let normalizedX = 0;
+        let normalizedY = 0;
+
+        if (absX >= threshold) {
+          const signX = stickX >= 0 ? 1 : -1;
+          normalizedX = (signX * (absX - threshold)) / (1 - threshold);
+        }
+
+        if (absY >= threshold) {
+          const signY = stickY >= 0 ? 1 : -1;
+          normalizedY = (signY * (absY - threshold)) / (1 - threshold);
+        }
+
+        let accelerationMultiplier = 1.0;
+        if (acceleration !== 1.0 && movementDurationSeconds > 0) {
+          accelerationMultiplier = Math.pow(
+            acceleration,
+            movementDurationSeconds
+          );
+        }
+
+        let finalStickX = gamepad.axes[axisXIndex] || 0;
+        let finalStickY = gamepad.axes[axisYIndex] || 0;
+        if (scrollMapping.invertX) finalStickX = -finalStickX;
+        if (scrollMapping.invertY) finalStickY = -finalStickY;
+
+        if (
+          Math.abs(finalStickX) < threshold &&
+          Math.abs(finalStickY) < threshold
+        ) {
+          stickMovementStartTimeRef.current.delete(scrollStateKey);
+          scrollRemainderRef.current.delete(scrollStateKey);
+          return;
+        }
+
+        if (pendingMouseScrollsRef.current.has(scrollStateKey)) {
+          return;
+        }
+
+        const remainder =
+          scrollRemainderRef.current.get(scrollStateKey) ?? { x: 0, y: 0 };
+        const nextX =
+          remainder.x + normalizedX * sensitivity * accelerationMultiplier;
+        const nextY =
+          remainder.y + normalizedY * sensitivity * accelerationMultiplier;
+        const stepsX = nextX < 0 ? Math.ceil(nextX) : Math.floor(nextX);
+        const stepsY = nextY < 0 ? Math.ceil(nextY) : Math.floor(nextY);
+
+        scrollRemainderRef.current.set(scrollStateKey, {
+          x: nextX - stepsX,
+          y: nextY - stepsY,
+        });
+
+        sendMouseScroll(stepsX, stepsY, scrollStateKey);
+      });
+
+      // Process hotkey mappings (skip if a continuous mode is enabled for that stick)
       // Group by stick index to check for direct mappings efficiently
       const stickMappingsByStick = mapping.axisMappings.reduce(
         (acc, axisMapping) => {
           if (
             axisMapping.type === "hotkey" &&
-            !sticksWithMouse.has(axisMapping.stickIndex)
+            !sticksWithContinuous.has(axisMapping.stickIndex)
           ) {
             acc.set(
               axisMapping.stickIndex,
@@ -690,12 +875,27 @@ export function useGamepadMapping(gamepads: GamepadState[]) {
               isActive = fallbackDirections.includes(axisMapping.direction);
             }
 
+            if (isMouseWheelKey(axisMapping.key)) {
+              if (isActive) {
+                triggerMappedWheelScroll(axisMapping.key, stateKey);
+              }
+              return Promise.resolve();
+            }
+
             return simulateKeyPress(axisMapping.key, isActive, stateKey);
           })
         );
       });
     });
-  }, [gamepads, getMapping, getMouseMappings, simulateKeyPress]);
+  }, [
+    gamepads,
+    getMapping,
+    getMouseMappings,
+    getScrollMappings,
+    sendMouseScroll,
+    simulateKeyPress,
+    triggerMappedWheelScroll,
+  ]);
 
   return {
     mappings,

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -5,6 +5,7 @@ export interface KeySimulator {
 export interface MouseSimulator {
   moveMouse: (deltaX: number, deltaY: number) => Promise<{ success: boolean; error?: string }>
   buttonToggle: (button: string, down: boolean) => Promise<{ success: boolean; error?: string }>
+  scrollMouse: (deltaX: number, deltaY: number) => Promise<{ success: boolean; error?: string }>
 }
 
 export interface IpcRenderer {
@@ -21,4 +22,3 @@ declare global {
     ipcRenderer?: IpcRenderer
   }
 }
-


### PR DESCRIPTION
## Summary
- Add `mouse-scroll` IPC support and expose `scrollMouse` to the renderer.
- Add wheel bindings for buttons, D-pad, and stick hotkey mappings.
- Add a stick scroll mode with sensitivity, acceleration, inversion, and remainder handling.
- Smooth continuous stick scrolling by avoiding per-stick IPC back-pressure, accumulating deltas from frame elapsed time, and dispatching native wheel events through `libnut.scrollMouse`.

## Verification
- `npx tsc`
- `npx vite build`
- Built and installed a local macOS app for manual scroll-wheel testing.

<img width="1692" height="1072" alt="image" src="https://github.com/user-attachments/assets/08912ad9-1bc5-46c3-ac5c-938eb286762b" />
